### PR TITLE
Remove "requireCamelCaseOrUpperCaseIdentifiers" from jscsrc

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -30,7 +30,7 @@
     "requireSpacesInConditionalExpression": true,
     "requireBlocksOnNewline": 1,
     "requireCommaBeforeLineBreak": true,
-    "requireSpaceBeforeBinaryOperators"        : [
+    "requireSpaceBeforeBinaryOperators": [
         "?",
         "+",
         "-",
@@ -47,7 +47,6 @@
         "<="
     ],
     "requireSpaceAfterBinaryOperators": true,
-    "requireCamelCaseOrUpperCaseIdentifiers": true,
     "requireLineFeedAtFileEnd": true,
     "requireCapitalizedConstructors": true,
     "requireDotNotation": true,
@@ -105,7 +104,6 @@
         ":"
     ],
     "requireBlocksOnNewline": true,
-    "requireCamelCaseOrUpperCaseIdentifiers": true,
     "safeContextKeyword": "PleaseUseFunctionDotPrototypeDotBind",
     "validateLineBreaks": "LF",
     "validateQuoteMarks": "'",


### PR DESCRIPTION
Supprime la règle "requireCamelCaseOrUpperCaseIdentifiers" du jscsrc qui fait doublon avec la règle "camelcase" d'eslintrc_base (ce qui n'est pas pratique pour une désactivation locale de la règle).