### PR TITLE
Removed unsupported esnext option

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,5 +1,4 @@
 {
-    "esnext": true,
     "disallowDanglingUnderscores": true,
     "disallowSpacesInNamedFunctionExpression": {
         "beforeOpeningRoundBrace": true
@@ -108,7 +107,6 @@
     "validateLineBreaks": "LF",
     "validateQuoteMarks": "'",
     "validateIndentation": 2,
-    "esnext": true,
     "excludeFiles": [
         "node_modules/**"
     ],


### PR DESCRIPTION
esnext option is not supported anymore in .jscsrc

http://jscs.info/overview#options