### PR TITLE
Shrinkwrap Flow

### DIFF
--- a/shrinkwrap.md
+++ b/shrinkwrap.md
@@ -28,8 +28,9 @@ By default (**it's not the behaviour we want**), npm install recursively install
 
 # How to add a new dependency
 
-- `npm i my-new-dependency -s`
-- `rm -r node_modules npm-shrinkwrap.json && npm i --production && npm shrinkwrap` because we should not lock down devDependencies
+- `rm -r node_modules && npm i --production` ensure to have latest libraries from shrinkwrap
+- `npm i my-new-dependency@version -s` install new dependency in right version
+- `npm shrinkwrap` update only our dependency
 - commit both updated `package.json` and `npm-shrinkwrap.json`
 - push, done.
 

--- a/shrinkwrap.md
+++ b/shrinkwrap.md
@@ -29,7 +29,7 @@ By default (**it's not the behaviour we want**), npm install recursively install
 # How to add a new dependency
 
 - `rm -r node_modules && npm i --production` ensure to have latest libraries from shrinkwrap
-- `npm i my-new-dependency@version -s` install new dependency in right version
+- `npm i my-new-dependency@version -E` install new dependency in right version
 - `npm shrinkwrap` update only our dependency
 - commit both updated `package.json` and `npm-shrinkwrap.json`
 - push, done.


### PR DESCRIPTION
Ne jamais supprimer le fichier npm-shrinkwrap.json, ou seulement pendant les jours d'update de lib.

Si il est supprimé, le npm install se basera sur le fichier package.json, et on s'expose au fait que des versions ne soient pas figées, ce qui engendre des updates de versions potentiellement non voulues